### PR TITLE
Add win popup overlay for Mines game

### DIFF
--- a/pixi-blank/src/ease.js
+++ b/pixi-blank/src/ease.js
@@ -28,4 +28,12 @@ export default class Ease {
 
     return 1 + c3 * Math.pow(x - 1, 3) + c1 * Math.pow(x - 1, 2);
   }
+
+  static easeInOutQuad(x) {
+    return x < 0.5 ? 2 * x * x : 1 - Math.pow(-2 * x + 2, 2) / 2;
+  }
+
+  static easeOutQuad(x) {
+    return 1 - (1 - x) * (1 - x);
+  }
 }

--- a/pixi-blank/src/main.js
+++ b/pixi-blank/src/main.js
@@ -70,6 +70,9 @@ const game = await createMinesGame("#mines", {
       game.setSelectedCardIsDiamond();
     }
   },
+  onWin: () => {
+    game.showWinPopup(24.75, "0.00000000");
+  },
 });
 
 document

--- a/pixi-blank/src/main.js
+++ b/pixi-blank/src/main.js
@@ -59,6 +59,11 @@ const game = await createMinesGame("#mines", {
   explosionSheetScaleFit: 0.8, // how much of the tile size it occupies
   explosionSheetOpacity: 0.75, // sprite's transparency
 
+  /* Win pop-up */
+  winPopupShowDuration: 260, // in ms
+  winPopupWidth: 240, // in px
+  winPopupHeight: 170, // in px
+
   // Event callback for when a card is selected
   onCardSelected: ({ row, col, tile }) => {
     // TODO: Add code here to either call "game.SetSelectedCardIsBomb();" or "game.setSelectedCardIsDiamond();"

--- a/pixi-blank/src/mines.js
+++ b/pixi-blank/src/mines.js
@@ -104,6 +104,11 @@ export async function createMinesGame(mount, opts = {}) {
   const explosionSheetScaleFit = opts.explosionSheetScaleFit ?? 0.8;
   const explosionSheetOpacity = opts.explosionSheetOpacity ?? 0.75;
 
+  /* Win pop-up */
+  const winPopupShowDuration = opts.winPopupShowDuration ?? 260;
+  const winPopupWidth = opts.winPopupWidth ?? 240;
+  const winPopupHeight = opts.winPopupHeight ?? 170;
+
   // Resolve mount element
   const root =
     typeof mount === "string" ? document.querySelector(mount) : mount;
@@ -258,8 +263,8 @@ export async function createMinesGame(mount, opts = {}) {
   }
 
   function createWinPopup() {
-    const popupWidth = 240;
-    const popupHeight = 170;
+    const popupWidth = winPopupWidth;
+    const popupHeight = winPopupHeight;
 
     const container = new Container();
     container.visible = false;
@@ -280,13 +285,7 @@ export async function createMinesGame(mount, opts = {}) {
 
     const inner = new Graphics();
     inner
-      .roundRect(
-        -popupWidth / 2,
-        -popupHeight / 2,
-        popupWidth,
-        popupHeight,
-        28
-      )
+      .roundRect(-popupWidth / 2, -popupHeight / 2, popupWidth, popupHeight, 28)
       .fill(0x0f2b1a);
 
     const multiplierText = new Text({
@@ -337,10 +336,7 @@ export async function createMinesGame(mount, opts = {}) {
 
     const layoutAmountRow = () => {
       const spacing = 12;
-      coinContainer.position.set(
-        amountText.width + spacing + coinRadius,
-        0
-      );
+      coinContainer.position.set(amountText.width + spacing + coinRadius, 0);
       amountRow.pivot.set(amountRow.width / 2, amountRow.height / 2);
       amountRow.position.set(0, 34);
     };
@@ -379,7 +375,10 @@ export async function createMinesGame(mount, opts = {}) {
   }
 
   function formatMultiplier(multiplierValue) {
-    if (typeof multiplierValue === "number" && Number.isFinite(multiplierValue)) {
+    if (
+      typeof multiplierValue === "number" &&
+      Number.isFinite(multiplierValue)
+    ) {
       return `${multiplierValue.toFixed(2)}×`;
     }
 
@@ -410,8 +409,8 @@ export async function createMinesGame(mount, opts = {}) {
     winPopup.container.scale.set(0);
 
     tween(app, {
-      duration: 260,
-      ease: (t) => t,
+      duration: winPopupShowDuration,
+      ease: (t) => Ease.easeOutQuad(t),
       update: (p) => {
         winPopup.container.scale.set(p);
       },


### PR DESCRIPTION
## Summary
- add a centered win popup with drop shadow, multiplier, amount text, and coin icon that scales in when shown
- expose a `showWinPopup` helper, ensure it repositions on resize/reset, and include it in the public API
- call the new helper from `main.js` when the win callback fires so the UI appears after a successful game

## Testing
- npm run build *(fails: Vite cannot resolve ../assets/Sprites/Diamond.png and index.html parse errors)*

------
https://chatgpt.com/codex/tasks/task_e_68e038613ddc8323bd1a676c67bbf7fc