### PR TITLE
Ignore redundant pixi-blank workspace

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ pnpm-debug.log*
 lerna-debug.log*
 
 node_modules
+pixi-blank/
 dist
 dist-ssr
 *.local


### PR DESCRIPTION
## Summary
- ensure the redundant pixi-blank workspace is ignored so its duplicate node_modules tree is not committed
- confirmed no project tooling references the pixi-blank path

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e070a9b7948323a56e6d26b4190bf7