### PR TITLE
Ensure Pixi game canvas fits container

### DIFF
--- a/index.html
+++ b/index.html
@@ -66,11 +66,14 @@
             padding: 20px;
             backdrop-filter: blur(10px);
             box-shadow: 0 8px 32px rgba(0, 0, 0, 0.3);
+            flex: 1 1 320px;
+            display: flex;
+            justify-content: center;
         }
 
         #mines {
-            width: 600px;
-            height: 600px;
+            width: min(100%, 600px);
+            aspect-ratio: 1 / 1;
             border-radius: 8px;
             overflow: hidden;
             position: relative;
@@ -79,8 +82,9 @@
         }
 
         #mines canvas {
+            width: 100%;
+            height: 100%;
             display: block;
-            border: 2px solid rgba(227, 229, 82, 0.5);
         }
 
         .controls {
@@ -216,11 +220,12 @@
 
         /* Responsive Design */
         @media (max-width: 768px) {
-            #mines {
+            .game-container {
                 width: 100%;
-                max-width: 500px;
-                height: auto;
-                aspect-ratio: 1;
+            }
+
+            #mines {
+                width: min(100%, 500px);
             }
 
             h1 {


### PR DESCRIPTION
## Summary
- make the game panel flexibly size to its container and prevent overflow
- ensure the Pixi canvas scales responsively with a preserved square aspect ratio

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e24ebcca9c8323a86bd633bfc5346d