### PR TITLE
Add dynamic total profit label to control panel

### DIFF
--- a/index.html
+++ b/index.html
@@ -100,6 +100,17 @@
             gap: 10px;
         }
 
+        .control-stat {
+            background: rgba(255, 255, 255, 0.08);
+            border-radius: 10px;
+            padding: 14px 16px;
+            font-size: 1rem;
+            font-weight: 600;
+            color: #ffffff;
+            letter-spacing: 0.3px;
+            box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.05);
+        }
+
         .control-group h3 {
             font-size: 1rem;
             color: #E3E552;
@@ -291,6 +302,13 @@
                     <div class="button-group">
                         <button id="diamondBtn">💎 Diamond</button>
                         <button id="bombBtn">💣 Bomb</button>
+                    </div>
+                </div>
+
+                <div class="control-group">
+                    <h3>Game Stats</h3>
+                    <div class="control-stat" data-total-profit-display>
+                        Total Profit(1.00x
                     </div>
                 </div>
             </div>

--- a/src/controlPanel.js
+++ b/src/controlPanel.js
@@ -1,0 +1,42 @@
+const TOTAL_PROFIT_SELECTOR = "[data-total-profit-display]";
+
+let totalProfitDisplayEl = null;
+let currentTotalProfitMultiplier = 1;
+
+function resolveTotalProfitElement() {
+  if (!totalProfitDisplayEl) {
+    totalProfitDisplayEl = document.querySelector(TOTAL_PROFIT_SELECTOR);
+  }
+  return totalProfitDisplayEl;
+}
+
+function formatMultiplier(multiplier) {
+  if (typeof multiplier === "number" && Number.isFinite(multiplier)) {
+    return multiplier.toFixed(2);
+  }
+
+  const parsed = Number.parseFloat(multiplier);
+  if (Number.isFinite(parsed)) {
+    return parsed.toFixed(2);
+  }
+
+  return currentTotalProfitMultiplier.toFixed(2);
+}
+
+export function updateTotalProfitMultiplier(multiplier = currentTotalProfitMultiplier) {
+  const target = resolveTotalProfitElement();
+  if (!target) {
+    return currentTotalProfitMultiplier;
+  }
+
+  const formatted = formatMultiplier(multiplier);
+  currentTotalProfitMultiplier = Number.parseFloat(formatted);
+  target.textContent = `Total Profit(${formatted}x`;
+
+  return currentTotalProfitMultiplier;
+}
+
+export function initControlPanel() {
+  currentTotalProfitMultiplier = 1;
+  updateTotalProfitMultiplier(currentTotalProfitMultiplier);
+}

--- a/src/main.js
+++ b/src/main.js
@@ -1,4 +1,5 @@
 import { createMinesGame } from "./mines.js";
+import { initControlPanel } from "./controlPanel.js";
 import diamondTextureUrl from "../assets/sprites/Diamond.png";
 import bombTextureUrl from "../assets/sprites/Bomb.png";
 import explosionSheetUrl from "../assets/sprites/Explosion_Spritesheet.png";
@@ -13,6 +14,7 @@ import gameStartSoundUrl from "../assets/sounds/GameStart.ogg";
 
 
 let game;
+initControlPanel();
 const opts = {
   // Window visuals
   size: 600,


### PR DESCRIPTION
## Summary
- add a styled total profit stat to the control panel and seed it with a 1.00x multiplier
- create a control panel helper that updates the total profit multiplier and wire it into the main entry point

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68f0e35f78c88323aa8d8b2c16d5ab44